### PR TITLE
Exclude assembly PDF from build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,9 +33,12 @@
           <resource>
             <directory>src/main/resources</directory>
             <filtering>true</filtering>
+            <excludes>
+              <exclude>com/wymarc/astrolabe/generator/reference/Astrolabe_assembly.pdf</exclude>
+            </excludes>
           </resource>
         </resources>
-				<plugins>
+                                <plugins>
 					<plugin>
 						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-compiler-plugin</artifactId>
@@ -72,6 +75,9 @@
           <resource>
             <directory>src/main/resources</directory>
             <filtering>true</filtering>
+            <excludes>
+              <exclude>com/wymarc/astrolabe/generator/reference/Astrolabe_assembly.pdf</exclude>
+            </excludes>
           </resource>
         </resources>
 				<plugins>


### PR DESCRIPTION
## Summary
- exclude `Astrolabe_assembly.pdf` from packaged resources

## Testing
- `mvn -q test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68ace9ea834c8331acf58cffe6cab696