### PR TITLE
Exclude assembly PDF from build resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,9 @@
           <resource>
             <directory>src/main/resources</directory>
             <filtering>true</filtering>
+            <excludes>
+              <exclude>com/wymarc/astrolabe/generator/reference/Astrolabe_assembly.pdf</exclude>
+            </excludes>
           </resource>
         </resources>
 				<plugins>
@@ -72,6 +75,9 @@
           <resource>
             <directory>src/main/resources</directory>
             <filtering>true</filtering>
+            <excludes>
+              <exclude>com/wymarc/astrolabe/generator/reference/Astrolabe_assembly.pdf</exclude>
+            </excludes>
           </resource>
         </resources>
 				<plugins>


### PR DESCRIPTION
## Summary
- exclude Astrolabe_assembly.pdf from packaged resources to keep assembly reference out of build

## Testing
- `mvn test` *(fails: PluginResolutionException due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aceb032e548331a52935fbf0f45adf